### PR TITLE
Phone number is required for credit card processing via PayPal

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function Construct(options, callback) {
       name: 'phone',
       label: 'Phone Number',
       type: 'string',
-      required: false
+      required: true
     },
     {
       name: 'description',

--- a/views/form.html
+++ b/views/form.html
@@ -7,7 +7,7 @@
   <label>Credit Card Information</label>
   {{ schemaFields(schema, {from: 'type', to: 'expire_year'}) }}
   <label>Billing Information</label>
-  {{ schemaFields(schema, {from: 'line1', to: 'email'}) }}
+  {{ schemaFields(schema, {from: 'line1', to: 'phone'}) }}
   <input value="Donate" type="submit"/>
   <div class="apos-donate-pending"><img src="/modules/donate/images/spinner.gif"></div>
 </form>


### PR DESCRIPTION
I set this up in a project and began testing with the packaged form templates. The error messages I received indicated that a phone number was required:

```
{ [Error: Response Status : 400]
  response:
   { name: 'VALIDATION_ERROR',
     details: [ [Object] ],
     message: 'Invalid request - see details',
     information_link: 'https://developer.paypal.com/webapps/developer/docs/api/#VALIDATION_ERROR',
     debug_id: '18ece70ce75b7' },
  httpStatusCode: 400 }
[ { field: 'payer.funding_instruments[0].credit_card.billing_address.phone',
    issue: 'Phone number must be in this format: optional leading \'+\' followed by [0-9], spaces, hyphens, periods, and matching parentheses (not nested)' } ]
{ number: 'Your credit card was not accepted. Please double check your information.' }
```

Once I made these changes I was able to successfully submit a test transaction using the built in templates.
